### PR TITLE
[sms] Be specific about API reference for SMS

### DIFF
--- a/docs/sms-receive-how-to.md
+++ b/docs/sms-receive-how-to.md
@@ -46,7 +46,7 @@ Then you can add `sms-grpc` and `utils-grpc`:
 <GithubCode fileUrl="https://github.com/working-group-two/docs.wgtwo.com/blob/master/examples/sms/src/main/kotlin/ReceiveText.kt" />
 
 ## Resources
-* [Messagecore API reference](https://github.com/working-group-two/wgtwoapis/blob/master/wgtwo/sms/v0/sms.proto)
+* [SMS API reference](https://github.com/working-group-two/wgtwoapis/blob/master/wgtwo/sms/v0/sms.proto)
 
 ## Concepts
 * [wikipedia.org/wiki/SMS](https://en.wikipedia.org/wiki/SMS)

--- a/docs/sms-send-how-to.md
+++ b/docs/sms-send-how-to.md
@@ -61,7 +61,7 @@ Then you can add `sms-grpc` and `utils-grpc`:
 <GithubCode fileUrl="https://github.com/working-group-two/docs.wgtwo.com/blob/master/examples/sms/src/main/kotlin/SendBinarySmsToSubscriber.kt" />
 
 ## Resources
-* [Messagecore API reference](https://github.com/working-group-two/wgtwoapis/blob/master/wgtwo/sms/v0/sms.proto)
+* [SMS API reference](https://github.com/working-group-two/wgtwoapis/blob/master/wgtwo/sms/v0/sms.proto)
 
 ## Concepts
 * [wikipedia.org/wiki/SMS](https://en.wikipedia.org/wiki/SMS)


### PR DESCRIPTION
Messagecore does not exist in public API (or will not very soon). Using 'SMS API' instead of 'Messagecore API'.