### PR TITLE
Move service list to separate section

### DIFF
--- a/docs/provision-api-reference.md
+++ b/docs/provision-api-reference.md
@@ -120,4 +120,4 @@ removed for this user.
 
 ### Service list
 
-The list of services available to provision is found here: [list of services](https://docs.wgtwo.com/subscription-profile/service-list/)
+The list of services available to provision is found here: [list of services](https://docs.wgtwo.com/subscription-profile/subscription-services/)

--- a/docs/provision-api-reference.md
+++ b/docs/provision-api-reference.md
@@ -114,37 +114,10 @@ removed for this user.
   * **name:** Service name from the service list.
 * **userid:** Unique user ID for this user.
 
-## Service list
-
-_Items marked 'Default' will be enabled upon activation._
- 
-| Service name                   | Description                                                      | Configuration                                         | Default
-|--------------------------------|------------------------------------------------------------------|-------------------------------------------------------| -------
-| DATA                           | Capped data speed                                                | N/A                                                   |
-| DATA_HIGHSPEED                 | Uncapped data speed                                              | N/A                                                   | Y
-| DATA_TETHERING                 | Share data through tethering                                     | N/A                                                   |
-| MMS_IN                         | Incoming MMS                                                     | N/A                                                   | Y
-| MMS_OUT                        | Outgoing MMS                                                     | N/A                                                   | Y
-| MMS_OUT_INTER                  | International MMS                                                | N/A                                                   | Y
-| PRODUCT_BUNDLING               | Include products from ecosystem                                  | "products": ["productCode1", "productCode2"]          |
-| ROAMING                        | Calls                                                            | N/A                                                   |
-| ROAMING_DATA                   | Data access while roaming                                        | N/A                                                   |
-| SMS_IN                         | Incoming SMS                                                     | N/A                                                   | Y
-| SMS_OUT                        | Outgoing domestic SMS                                            | N/A                                                   | Y
-| SMS_OUT_INTER                  | International SMS                                                | N/A                                                   | Y
-| SMS_PREMIUM                    | Premium content SMS                                              | N/A                                                   |
-| VOICE_CALLFORWARD              | Forward calls                                                    | 1 or more "condition" : "fwd_number" with condition in  unconditional \| busy \| no_reply \| unreachable
-| VOICE_CALLWAITING              | If busy, let new callers wait instead of dropping with busy tone | N/A                                                   |
-| VOICE_IN                       | Incoming calls                                                   | N/A                                                   | Y
-| VOICE_MISSED_CALL_ALERT        | Missed call alert                                                | N/A                                                   | Y
-| VOICE_OUT                      | Outgoing domestic calls                                          | N/A                                                   | Y
-| VOICE_OUT_INTER                | International calls                                              | N/A                                                   |
-| VOICE_PREMIUM                  | Premium content calls                                            | N/A                                                   |
-| VOICE_VOICEMAIL                | Voicemail service                                                | N/A                                                   | Y
-| VOICE_VOLTE                    | Voice calls over LTE                                             | N/A                                                   |
-| VOICE_VOWIFI                   | Voice calls over WiFi                                            | N/A                                                   |
-| VOICEMAIL_DISABLE_NOTIFICATION | Disable voicemail notifications                                  | N/A                                                   |
-
 **Error cases:**
 * msisdn unknown
 * service name unknown
+
+### Service list
+
+The list of services available to provision is found here: [list of services](https://docs.wgtwo.com/subscription-profile/service-list/)

--- a/docs/provision-api-reference.md
+++ b/docs/provision-api-reference.md
@@ -120,4 +120,4 @@ removed for this user.
 
 ### Service list
 
-The list of services available to provision is found here: [list of services](https://docs.wgtwo.com/subscription-profile/subscription-services/)
+The list of services available to provision is found here: [list of services](/subscription-profile/subscription-services/)

--- a/docs/provision-service-list.md
+++ b/docs/provision-service-list.md
@@ -1,0 +1,35 @@
+---
+title: Subscription services
+topic: subscription profile
+type: api-reference
+hideWarning: true
+---
+
+# Service list
+
+| Service name                   | Description                                                      | Available in APIv1 | Available in APIv2 |
+|--------------------------------|------------------------------------------------------------------|--------------------|--------------------|
+| DATA                           | Data allowed                                                     | Y                  | Y                  |
+| DATA_HIGHSPEED                 | Data allowed at high speed                                       | Y                  | No                 |
+| DATA_TETHERING                 | Share data through tethering                                     | Y                  | Y                  |
+| MMS_IN                         | Incoming MMS                                                     | Y                  | Y                  |
+| MMS_OUT                        | Outgoing MMS                                                     | Y                  | Y                  |
+| MMS_OUT_INTER                  | International MMS                                                | Y                  | Y                  |
+| PRODUCT_BUNDLING               | Include products from ecosystem                                  | Y                  | Y                  |
+| ROAMING                        | Calls                                                            | Y                  | Y                  |
+| ROAMING_DATA                   | Data access while roaming                                        | Y                  | Y                  |
+| SMS_IN                         | Incoming SMS                                                     | Y                  | Y                  |
+| SMS_OUT                        | Outgoing domestic SMS                                            | Y                  | Y                  |
+| SMS_OUT_INTER                  | International SMS                                                | Y                  | Y                  |
+| SMS_PREMIUM                    | Premium content SMS                                              | Y                  | Y                  |
+| VOICE_CALLFORWARD              | Forward calls                                                    | Y                  | Y                  |
+| VOICE_CALLWAITING              | If busy, let new callers wait instead of dropping with busy tone | Y                  | Y                  |
+| VOICE_IN                       | Incoming calls                                                   | Y                  | Y                  |
+| VOICE_MISSED_CALL_ALERT        | Missed call alert                                                | Y                  | Y                  |
+| VOICE_OUT                      | Outgoing domestic calls                                          | Y                  | Y                  |
+| VOICE_OUT_INTER                | International calls                                              | Y                  | Y                  |
+| VOICE_PREMIUM                  | Premium content calls                                            | Y                  | Y                  |
+| VOICE_VOICEMAIL                | Voicemail service                                                | Y                  | Y                  |
+| VOICE_VOLTE                    | Voice calls over LTE                                             | Y                  | Y                  |
+| VOICE_VOWIFI                   | Voice calls over WiFi                                            | Y                  | Y                  |
+| VOICEMAIL_DISABLE_NOTIFICATION | Disable voicemail notifications                                  | Y                  | Y                  |


### PR DESCRIPTION
The first step of updating the service list.

- Move out service list to a separate section
- Remove 'Default' column
- Add columns for v1 and v2 provisioning API presence

There will be other PRs incoming on expanding the service list.